### PR TITLE
Support streaming data to ffmpeg/ffprobe's stdin

### DIFF
--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFbinaryInterface.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFbinaryInterface.java
@@ -1,5 +1,6 @@
 package nl.bravobit.ffmpeg;
 
+import java.io.InputStream;
 import java.util.Map;
 
 import nl.bravobit.ffmpeg.exceptions.FFcommandAlreadyRunningException;
@@ -12,11 +13,12 @@ interface FFbinaryInterface {
      *
      * @param environmentVars                 Environment variables
      * @param cmd                             command to execute
+     * @param stdin                           stream to feed into ffmpeg's stdin, or null to ignore
      * @param ffcommandExecuteResponseHandler {@link FFcommandExecuteResponseHandler}
      * @return the task
      * @throws FFmpegCommandAlreadyRunningException throws exception when binary is already running
      */
-    FFtask execute(Map<String, String> environmentVars, String[] cmd, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFcommandAlreadyRunningException;
+    FFtask execute(Map<String, String> environmentVars, String[] cmd, InputStream stdin, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFcommandAlreadyRunningException;
 
     /**
      * Executes a command
@@ -27,6 +29,17 @@ interface FFbinaryInterface {
      * @throws FFmpegCommandAlreadyRunningException throws exception when binary is already running
      */
     FFtask execute(String[] cmd, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFcommandAlreadyRunningException;
+
+    /**
+     * Executes a command
+     *
+     * @param cmd                             command to execute
+     * @param stdin                           stream to feed into ffmpeg's stdin, or null to ignore
+     * @param ffcommandExecuteResponseHandler {@link FFcommandExecuteResponseHandler}
+     * @return the task
+     * @throws FFmpegCommandAlreadyRunningException throws exception when binary is already running
+     */
+    FFtask execute(String[] cmd, InputStream stdin, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFcommandAlreadyRunningException;
 
     /**
      * Checks if FF binary is supported on this device

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFcommandExecuteAsyncTask.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFcommandExecuteAsyncTask.java
@@ -4,6 +4,7 @@ import android.os.AsyncTask;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.concurrent.TimeoutException;
@@ -11,6 +12,7 @@ import java.util.concurrent.TimeoutException;
 class FFcommandExecuteAsyncTask extends AsyncTask<Void, String, CommandResult> implements FFtask {
 
     private final String[] cmd;
+    private final InputStream in;
     private final FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler;
     private final ShellCommand shellCommand;
     private final long timeout;
@@ -21,6 +23,15 @@ class FFcommandExecuteAsyncTask extends AsyncTask<Void, String, CommandResult> i
 
     FFcommandExecuteAsyncTask(String[] cmd, long timeout, FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler) {
         this.cmd = cmd;
+        this.in = null;
+        this.timeout = timeout;
+        this.ffmpegExecuteResponseHandler = ffmpegExecuteResponseHandler;
+        this.shellCommand = new ShellCommand();
+    }
+
+    FFcommandExecuteAsyncTask(String[] cmd, InputStream in, long timeout, FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler) {
+        this.cmd = cmd;
+        this.in = in;
         this.timeout = timeout;
         this.ffmpegExecuteResponseHandler = ffmpegExecuteResponseHandler;
         this.shellCommand = new ShellCommand();
@@ -37,7 +48,7 @@ class FFcommandExecuteAsyncTask extends AsyncTask<Void, String, CommandResult> i
     @Override
     protected CommandResult doInBackground(Void... params) {
         try {
-            process = shellCommand.run(cmd);
+            process = shellCommand.run(cmd, in);
             if (process == null) {
                 return CommandResult.getDummyFailureResponse();
             }

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFmpeg.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFmpeg.java
@@ -111,14 +111,14 @@ public class FFmpeg implements FFbinaryInterface {
     }
 
     @Override
-    public FFtask execute(Map<String, String> environvenmentVars, String[] cmd, FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler) throws FFmpegCommandAlreadyRunningException {
+    public FFtask execute(Map<String, String> environvenmentVars, String[] cmd, InputStream in, FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler) throws FFmpegCommandAlreadyRunningException {
         if (ffmpegExecuteAsyncTask != null && !ffmpegExecuteAsyncTask.isProcessCompleted()) {
             throw new FFmpegCommandAlreadyRunningException("FFmpeg command is already running, you are only allowed to run single command at a time");
         }
         if (cmd.length != 0) {
             String[] ffmpegBinary = new String[]{FileUtils.getFFmpegCommand(context.provide(), environvenmentVars)};
             String[] command = concatenate(ffmpegBinary, cmd);
-            ffmpegExecuteAsyncTask = new FFcommandExecuteAsyncTask(command, timeout, ffmpegExecuteResponseHandler);
+            ffmpegExecuteAsyncTask = new FFcommandExecuteAsyncTask(command, in, timeout, ffmpegExecuteResponseHandler);
             ffmpegExecuteAsyncTask.execute();
             return ffmpegExecuteAsyncTask;
         } else {
@@ -140,7 +140,12 @@ public class FFmpeg implements FFbinaryInterface {
 
     @Override
     public FFtask execute(String[] cmd, FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler) throws FFmpegCommandAlreadyRunningException {
-        return execute(null, cmd, ffmpegExecuteResponseHandler);
+        return execute(null, cmd, null, ffmpegExecuteResponseHandler);
+    }
+
+    @Override
+    public FFtask execute(String[] cmd, InputStream in, FFcommandExecuteResponseHandler ffmpegExecuteResponseHandler) throws FFmpegCommandAlreadyRunningException {
+        return execute(null, cmd, in, ffmpegExecuteResponseHandler);
     }
 
     @Override

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFprobe.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/FFprobe.java
@@ -111,14 +111,14 @@ public class FFprobe implements FFbinaryInterface {
     }
 
     @Override
-    public FFtask execute(Map<String, String> environvenmentVars, String[] cmd, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFprobeCommandAlreadyRunningException {
+    public FFtask execute(Map<String, String> environvenmentVars, String[] cmd, InputStream in, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFprobeCommandAlreadyRunningException {
         if (ffprobeExecuteAsyncTask != null && !ffprobeExecuteAsyncTask.isProcessCompleted()) {
             throw new FFprobeCommandAlreadyRunningException("FFprobe command is already running, you are only allowed to run single command at a time");
         }
         if (cmd.length != 0) {
             String[] ffprobeBinary = new String[]{FileUtils.getFFprobeCommand(context.provide(), environvenmentVars)};
             String[] command = concatenate(ffprobeBinary, cmd);
-            ffprobeExecuteAsyncTask = new FFcommandExecuteAsyncTask(command, timeout, ffcommandExecuteResponseHandler);
+            ffprobeExecuteAsyncTask = new FFcommandExecuteAsyncTask(command, in, timeout, ffcommandExecuteResponseHandler);
             ffprobeExecuteAsyncTask.execute();
             return ffprobeExecuteAsyncTask;
         } else {
@@ -140,7 +140,12 @@ public class FFprobe implements FFbinaryInterface {
 
     @Override
     public FFtask execute(String[] cmd, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFprobeCommandAlreadyRunningException {
-        return execute(null, cmd, ffcommandExecuteResponseHandler);
+        return execute(null, cmd, null, ffcommandExecuteResponseHandler);
+    }
+
+    @Override
+    public FFtask execute(String[] cmd, InputStream in, FFcommandExecuteResponseHandler ffcommandExecuteResponseHandler) throws FFprobeCommandAlreadyRunningException {
+        return execute(null, cmd, in, ffcommandExecuteResponseHandler);
     }
 
     @Override

--- a/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/ShellCommand.java
+++ b/android-ffmpeg/src/main/java/nl/bravobit/ffmpeg/ShellCommand.java
@@ -1,14 +1,62 @@
 package nl.bravobit.ffmpeg;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Arrays;
 
 class ShellCommand {
 
-    Process run(String[] commandString) {
+    private class PipeWriter implements Runnable
+    {
+        final InputStream in;
+        final OutputStream out;
+
+        PipeWriter(InputStream in, OutputStream out)
+        {
+            this.in = in;
+            this.out = out;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                byte [] buffer = new byte[10*1024];
+                int length;
+                while ( (length = in.read(buffer)) > 0)
+                {
+                    out.write(buffer, 0, length);
+                }
+            }
+            catch(IOException e)
+            {
+                Log.e("Exception while trying to write to ffmpeg stdin", e);
+            }
+            finally
+            {
+                try
+                {
+                    out.close();
+                }
+                catch (IOException e)
+                {
+                    Log.e("Failed to close stream", e);
+                }
+            }
+        }
+    }
+
+    Process run(String[] commandString, final InputStream pipeToStdin) {
         Process process = null;
         try {
             process = Runtime.getRuntime().exec(commandString);
+            if(pipeToStdin != null)
+            {
+                new Thread(new PipeWriter(pipeToStdin, process.getOutputStream())).start();
+            }
+
         } catch (IOException e) {
             Log.e("Exception while trying to run: " + Arrays.toString(commandString), e);
         }


### PR DESCRIPTION
It is common for intents in Android to provide data as a uri,
which may not be directly resolvable to a file path. Instead,
a uri can be resolved as an input stream. To allow ffmpeg and
ffprobe to consume such data, this change adds support for streaming
data to the forked process' stdin.